### PR TITLE
fix: prop style undefined

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -384,7 +384,9 @@ class List<Value = string> extends React.Component<IProps<Value>> {
     const listItemTouched = this.getChildren()[
       this.state.itemDragged
     ] as HTMLElement;
-    listItemTouched.style.touchAction = '';
+    if (listItemTouched && listItemTouched.style) {
+      listItemTouched.style.touchAction = '';
+    }
     const removeItem =
       this.props.removableByMove && this.isDraggedItemOutOfBounds();
     if (


### PR DESCRIPTION
Erro ao reordenar a lista com apenas dois itens e clicar em qualquer lugar após isso
`Uncaught TypeError: Cannot read property 'style' of undefined`